### PR TITLE
Corriger la taille des onglets en responsive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,6 +28,19 @@ body.dark-mode .cv-container {
     color: #e0e0e0;
     box-shadow: 0 0.5rem 1.5rem rgba(0,0,0,.3);
 }
+
+/* Animation douce des tabs */
+.nav-tabs .nav-item .nav-link {
+    transition: transform .2s ease-in-out, box-shadow .2s ease-in-out;
+}
+
+/* Effet de "lift" au survol de l'onglet */
+.nav-tabs .nav-item:hover .nav-link {
+    transform: translate3d(0, -.125rem, 0);
+    box-shadow: 0 .25rem .5rem rgba(0, 0, 0, .08);
+}
+
+
 .cv-left {
     background: #f0f3f7;
     min-height: 100%;

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             
             <!-- Nom et titre -->
             <div class="col-12 col-md">
-                <h1 class="cv-main-title h3 mb-1">ANTHONY DÉGEILH</h1>
+                <h1 class="cv-main-title h1 mb-1">ANTHONY DÉGEILH</h1>
                 <p class="lead fs-1 mb-2">Concepteur Développeur d'Applications</p>
                 <p class="fst-italic mb-0" style="width: 70%; margin: 0 auto ; text-align: justify;">
                     "Développeur web en formation ayant recentré sa carrière technique après une longue expérience industrielle.


### PR DESCRIPTION
- Création d'un `@media (max-width: 596px)` pour les écrans mobiles
- Création d'un `@media (max-width: 480px)` pour les très petits écrans

- Fix et modifications diverses sur le reste du document HTML